### PR TITLE
feat: support callable on column `class` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
 All notable changes to `:package_name` will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- `class` column option now accepts a `Closure(Model): ?string` in addition to a plain string. The closure is resolved against each row and applied to the cell only (the header skips row-dependent callables). Enables per-row styling such as greying out inactive rows. Backward compatible with the existing string usage.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,36 @@ FluxDataTable::columns([
 ])->data(User::query());
 ```
 
+### Per-column CSS classes
+
+Each column can declare a `class` option to apply CSS classes to its cells.
+Two forms are supported:
+
+- **Static string** — applied to both the column header and every cell of that column:
+
+```php
+[
+    'label' => 'Actions',
+    'field' => null,
+    'class' => 'bg-zinc-50',
+    'render' => fn ($row) => view('rows.actions', ['row' => $row]),
+],
+```
+
+- **Closure `fn ($row): ?string`** — evaluated against each row, only applied to the cell (the header has no row context and skips the callable). Useful to highlight, mute or otherwise discriminate a row based on its data:
+
+```php
+[
+    'label' => 'Provider name',
+    'field' => 'name',
+    'render' => fn ($row) => $row->name,
+    // grey out inactive rows
+    'class' => fn ($row) => $row->is_active ? null : 'text-zinc-400 italic',
+],
+```
+
+Returning `null` from the callable emits no class for that row. Both forms can be mixed across columns in the same table.
+
 ### Customizing Per-Page Options
 
 You can customize the per-page options:

--- a/resources/views/livewire/table.blade.php
+++ b/resources/views/livewire/table.blade.php
@@ -136,7 +136,10 @@
                         @php
                             $colId = $col['field'] ? \Illuminate\Support\Str::slug($col['field']) : $index;
                             $sticky = $col['sticky'] ?? false;
+                            // Sur le header, on n'a pas de $row : un `class` callable n'a pas
+                            // de sens ici, on l'ignore. Une string reste appliquée.
                             $class = $col['class'] ?? null;
+                            $class = is_string($class) ? $class : null;
                         @endphp
                         <flux:table.column
                             x-data="{ sortable: {{ isset($col['sortable']) && $col['sortable'] ? 'true' : 'false' }} }"
@@ -182,7 +185,13 @@
                                 @php
                                     $colId = $col['field'] ? \Illuminate\Support\Str::slug($col['field']) : $index;
                                     $sticky = $col['sticky'] ?? false;
+                                    // `class` peut être soit une string, soit un callable
+                                    // `fn($row): ?string` pour conditionner les classes
+                                    // sur la ligne (ex : griser les inactifs).
                                     $class = $col['class'] ?? null;
+                                    if (is_callable($class)) {
+                                        $class = $class($row);
+                                    }
                                 @endphp
                                 <flux:table.cell :align="$col['align'] ?? 'center'" variant="strong" :wire:key="'row-cell-' . $rowId . '-' . $colId" :sticky="$sticky" @class([$class => $class])>
                                     @if(isset($col['render']))

--- a/tests/Feature/ColumnClassTest.php
+++ b/tests/Feature/ColumnClassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Livewire\Livewire;
+use Ultraviolettes\FluxDataTable\Tests\Fixtures\ColumnClassTable;
+use Ultraviolettes\FluxDataTable\Tests\Fixtures\Item;
+
+beforeEach(function () {
+    Item::query()->delete();
+    Item::query()->create(['name' => 'Alpha']);
+    Item::query()->create(['name' => 'Bravo']);
+    Item::query()->create(['name' => 'Charlie']);
+});
+
+it('applies a string class on cells (legacy behavior)', function () {
+    Livewire::test(ColumnClassTable::class)
+        ->assertSee('static-class', false);
+});
+
+it('resolves a callable class against each row on cells', function () {
+    // id=1 → odd, id=2 → even, id=3 → odd
+    $html = Livewire::test(ColumnClassTable::class)->html();
+
+    expect(substr_count($html, 'odd-row'))->toBe(2);
+    expect(substr_count($html, 'even-row'))->toBe(1);
+});
+
+it('does not emit a class when the callable returns null for a given row', function () {
+    // class `fn ($row) => $row->id === 1 ? 'first-only' : null` :
+    // only the first row should carry the class.
+    $html = Livewire::test(ColumnClassTable::class)->html();
+
+    expect(substr_count($html, 'first-only'))->toBe(1);
+});
+
+it('does not apply the callable class on the header (no row context)', function () {
+    // The header for column 2 ("Dyn") must not emit 'odd-row' / 'even-row'
+    // (the column header iteration cannot resolve a row-dependent callable).
+    // We assert by counting cell-side occurrences match exactly the row count.
+    $html = Livewire::test(ColumnClassTable::class)->html();
+
+    // 3 rows total ; odd_row twice + even_row once = 3 occurrences only.
+    // If the header also rendered the callable, it would add an extra one.
+    expect(substr_count($html, 'odd-row') + substr_count($html, 'even-row'))->toBe(3);
+});
+
+it('still applies a string class on the header (legacy behavior)', function () {
+    // 'static-class' should appear on both the <th> and 3 <td> = 4 occurrences.
+    $html = Livewire::test(ColumnClassTable::class)->html();
+
+    expect(substr_count($html, 'static-class'))->toBe(4);
+});

--- a/tests/Fixtures/ColumnClassTable.php
+++ b/tests/Fixtures/ColumnClassTable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Ultraviolettes\FluxDataTable\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Builder;
+use Ultraviolettes\FluxDataTable\Livewire\FluxDataTable;
+
+/**
+ * Fixture exercising the column `class` option in its two supported forms :
+ * - static string (legacy behavior, applied to both header and cells)
+ * - Closure(Model): ?string (per-row, cell-only)
+ */
+class ColumnClassTable extends FluxDataTable
+{
+    public function columns(): array
+    {
+        return [
+            [
+                'label' => 'Static',
+                'field' => 'name',
+                'render' => fn ($row) => $row->name,
+                'class' => 'static-class',
+            ],
+            [
+                'label' => 'Dyn',
+                'field' => 'dyn',
+                'render' => fn ($row) => $row->name,
+                'class' => fn ($row) => $row->id % 2 === 0 ? 'even-row' : 'odd-row',
+            ],
+            [
+                'label' => 'Maybe',
+                'field' => 'maybe',
+                'render' => fn ($row) => '-',
+                'class' => fn ($row) => $row->id === 1 ? 'first-only' : null,
+            ],
+        ];
+    }
+
+    public function builder(): Builder
+    {
+        return Item::query()->orderBy('id');
+    }
+}


### PR DESCRIPTION
## Summary

The column `class` option now accepts a `Closure(Model): ?string` in addition to the existing string form. The closure is resolved against each row and applied to **the cell only** — the header context ignores row-dependent callables since it has no row to pass. Returning `null` emits no class for that row.

Backward compatible : existing `'class' => 'some-class'` strings keep being applied to both the header and the cells exactly as before.

## Motivation

Consumers regularly want per-row styling — greying out inactive rows, highlighting overdue items, badging risky entries. Today this forces every column `render` callback to be wrapped in conditional HTML, which mixes styling concerns into the content rendering and gets verbose fast. With this change the styling lives where it belongs — as a column metadata option.

## Example

```php
public function columns(): array
{
    return [
        [
            'label' => 'Provider name',
            'field' => 'name',
            'render' => fn ($row) => $row->name,
            // grey out inactive rows
            'class' => fn ($row) => $row->is_active ? null : 'text-zinc-400 italic',
        ],
        [
            'label' => 'Actions',
            'field' => null,
            'class' => 'bg-zinc-50', // still works on header + cells
            'render' => fn ($row) => view('rows.actions', ['row' => $row]),
        ],
    ];
}
```

## Implementation

`resources/views/livewire/table.blade.php`:

- **Cell context** (per row in the loop) — if `$col['class']` is callable, invoke it with `$row` and use the returned `?string`.
- **Header context** (no row available) — if `$col['class']` is callable, fall back to `null`. Strings still apply.

## Test plan

- [x] String `class` still applied on header + cells (legacy).
- [x] Callable `class` resolved per row, only emitted on cells matching the truthy branch.
- [x] Callable returning `null` for a given row emits no class for that row.
- [x] Callable not invoked in header context.
- [x] Full package test suite (Pest) green : `28 tests, 35 assertions`.

Tests live in `tests/Feature/ColumnClassTest.php` and `tests/Fixtures/ColumnClassTable.php`.

## Docs

- README : new « Per-column CSS classes » section documenting both forms.
- CHANGELOG : Unreleased entry under `### Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)